### PR TITLE
Add ELKA-0 landing page, styles, portfolio links and markup cleanup

### DIFF
--- a/ai.html
+++ b/ai.html
@@ -214,6 +214,28 @@
             <h2 id="systems-title" class="section-title">Systems</h2>
             <div class="cards-grid cards-grid--projects">
 
+                <article class="card card--project" id="ai-elka-0">
+                    <figure class="card__media">
+                        <img src="/assets/images/ai/ai-banner.png" alt="ELKA-0 cognition engine architecture" loading="lazy"
+                            decoding="async" />
+                    </figure>
+                    <div class="card__body">
+                        <h3 class="card__title">ELKA-0 - Open Cognitive Engine</h3>
+                        <p class="card__desc">
+                            The cognition engine under Kael: memory-native reasoning, multimodal grounding, structured
+                            planning, and safety-aware decision logic for embodied AI systems.
+                        </p>
+                        <ul class="chipset" role="list">
+                            <li class="chip">Memory-Native</li>
+                            <li class="chip">Multimodal</li>
+                            <li class="chip">Safety Logic</li>
+                            <li class="chip">Open Source</li>
+                        </ul>
+                        <p><a class="btn" href="/elka-0/">Open ELKA-0 Page</a></p>
+                    </div>
+                </article>
+
+
                 <article class="card card--project" id="ai-luna">
                     <figure class="card__media">
                         <img src="/assets/images/ai/ai-luna.png" alt="Luna on-device assistant UI" loading="lazy"

--- a/ai/index.html
+++ b/ai/index.html
@@ -214,6 +214,28 @@
             <h2 id="systems-title" class="section-title">Systems</h2>
             <div class="cards-grid cards-grid--projects">
 
+                <article class="card card--project" id="ai-elka-0">
+                    <figure class="card__media">
+                        <img src="/assets/images/ai/ai-banner.png" alt="ELKA-0 cognition engine architecture" loading="lazy"
+                            decoding="async" />
+                    </figure>
+                    <div class="card__body">
+                        <h3 class="card__title">ELKA-0 - Open Cognitive Engine</h3>
+                        <p class="card__desc">
+                            The cognition engine under Kael: memory-native reasoning, multimodal grounding, structured
+                            planning, and safety-aware decision logic for embodied AI systems.
+                        </p>
+                        <ul class="chipset" role="list">
+                            <li class="chip">Memory-Native</li>
+                            <li class="chip">Multimodal</li>
+                            <li class="chip">Safety Logic</li>
+                            <li class="chip">Open Source</li>
+                        </ul>
+                        <p><a class="btn" href="/elka-0/">Open ELKA-0 Page</a></p>
+                    </div>
+                </article>
+
+
                 <article class="card card--project" id="ai-luna">
                     <figure class="card__media">
                         <img src="/assets/images/ai/ai-luna.png" alt="Luna on-device assistant UI" loading="lazy"

--- a/assets/css/elka-0.css
+++ b/assets/css/elka-0.css
@@ -1,0 +1,147 @@
+@layer pages {
+  body[data-route="elka-0"] {
+    --elka-bg: #07090f;
+    --elka-surface: #0f1422;
+    --elka-surface-2: #141b2e;
+    --elka-border: rgba(114, 158, 255, 0.25);
+    --elka-accent: #48a7ff;
+    --elka-accent-soft: rgba(72, 167, 255, 0.15);
+    --elka-text-soft: #b8c2d9;
+    --elka-grid: rgba(72, 167, 255, 0.08);
+    background:
+      linear-gradient(var(--elka-grid) 1px, transparent 1px),
+      linear-gradient(90deg, var(--elka-grid) 1px, transparent 1px),
+      radial-gradient(circle at 20% 10%, rgba(72, 167, 255, 0.2), transparent 32%),
+      radial-gradient(circle at 80% 0%, rgba(58, 238, 205, 0.14), transparent 24%),
+      var(--elka-bg);
+    background-size: 44px 44px, 44px 44px, auto, auto, auto;
+    background-attachment: fixed;
+  }
+
+  .elka-main {
+    color: #f7f9ff;
+    padding-bottom: 4rem;
+  }
+
+  .elka-section {
+    width: min(100% - 24px, 1100px);
+    margin: 0 auto;
+    padding: 1rem 0 2.2rem;
+  }
+
+  .elka-surface {
+    background: linear-gradient(160deg, rgba(18, 25, 44, 0.98), rgba(9, 13, 25, 0.97));
+    border: 1px solid var(--elka-border);
+    border-radius: 18px;
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.34);
+    padding: clamp(1rem, 2vw, 1.8rem);
+  }
+
+  .elka-hero {
+    min-height: 62dvh;
+    display: grid;
+    align-items: center;
+    padding-top: 1.2rem;
+  }
+
+  .elka-eyebrow {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: #9ac9ff;
+    margin: 0 0 0.7rem;
+  }
+
+  .elka-title { font-size: clamp(2rem, 8vw, 5rem); line-height: 1.02; margin: 0; }
+  .elka-subtitle { font-size: clamp(1rem, 2.6vw, 1.55rem); color: #dbe7ff; margin: 0.55rem 0 1rem; }
+  .elka-lead { max-width: 80ch; color: var(--elka-text-soft); margin: 0; }
+
+  .elka-cta { display: flex; flex-wrap: wrap; gap: 0.7rem; margin-top: 1.2rem; }
+  .elka-cta--center { justify-content: center; }
+
+  .btn.btn--elka { background: var(--elka-accent); border-color: transparent; color: #031428; }
+  .btn.btn--elka:hover { background: #8bc7ff; }
+  .btn.secondary.btn--elka { color: #e7f1ff; border-color: var(--elka-border); background: transparent; }
+  .btn.secondary.btn--elka:hover { background: var(--elka-accent-soft); }
+
+  .elka-section h2 { margin: 0 0 .35rem; font-size: clamp(1.2rem, 2.7vw, 2rem); }
+  .elka-intro { color: var(--elka-text-soft); margin: 0 0 1rem; }
+
+  .stack-flow {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0,1fr));
+    gap: 0.65rem;
+    align-items: center;
+  }
+
+  .stack-node {
+    background: var(--elka-surface-2);
+    border: 1px solid var(--elka-border);
+    border-radius: 14px;
+    padding: 1rem;
+  }
+
+  .stack-arrow { text-align: center; color: #7fbaff; font-weight: 700; font-size: 1.2rem; }
+
+  .elka-list,
+  .elka-grid,
+  .elka-flow,
+  .roadmap,
+  .eval-grid,
+  .deployment-grid,
+  .use-grid,
+  .dev-grid,
+  .oss-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.7rem;
+  }
+
+  .elka-list li,
+  .elka-grid li,
+  .eval-grid li,
+  .deployment-grid li,
+  .use-grid li,
+  .dev-grid li,
+  .oss-grid li,
+  .roadmap li {
+    background: var(--elka-surface-2);
+    border: 1px solid var(--elka-border);
+    border-radius: 12px;
+    padding: .82rem .9rem;
+  }
+
+  .elka-grid { grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+  .use-grid,.deployment-grid,.dev-grid,.oss-grid,.eval-grid { grid-template-columns: repeat(auto-fit, minmax(210px,1fr)); }
+
+  .elka-flow { grid-template-columns: repeat(6, minmax(0, 1fr)); align-items: center; }
+  .flow-step { text-align: center; }
+  .flow-arrow { text-align: center; color: #83b9ff; font-size: 1.3rem; }
+
+  .roadmap li { display: flex; gap: 0.65rem; align-items: baseline; }
+  .roadmap code { color: #9dd4ff; font-size: .9rem; min-width: 3.5rem; }
+
+  .status-chip {
+    display: inline-block;
+    padding: .25rem .55rem;
+    border-radius: 999px;
+    border: 1px solid var(--elka-border);
+    background: rgba(144, 193, 255, 0.08);
+    font-size: .8rem;
+    margin-top: .45rem;
+  }
+
+  .final-cta {
+    text-align: center;
+    background: linear-gradient(130deg, rgba(72, 167, 255, 0.22), rgba(14, 20, 35, 0.95));
+  }
+
+  @media (max-width: 900px) {
+    .stack-flow { grid-template-columns: 1fr; }
+    .stack-arrow { transform: rotate(90deg); }
+    .elka-flow { grid-template-columns: 1fr; }
+    .flow-arrow { transform: rotate(90deg); }
+  }
+}

--- a/elka-0.html
+++ b/elka-0.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="en" data-app="1807" data-page="elka-0" data-version="v1.0">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>ELKA-0 | The1807</title>
+  <link rel="canonical" href="https://the1807.xyz/elka-0/" />
+  <meta name="description" content="Open cognitive engine for memory-native embodied AI systems." />
+  <meta name="keywords" content="ELKA-0, The1807, Kael, cognitive engine, open-source AI, embodied AI, memory-native AI, multimodal AI" />
+  <meta name="theme-color" content="#07090f" />
+  <meta name="robots" content="index,follow,max-image-preview:large" />
+
+  <meta property="og:title" content="ELKA-0 | The1807" />
+  <meta property="og:description" content="Open cognitive engine for memory-native embodied AI systems." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://the1807.xyz/elka-0/" />
+  <meta property="og:image" content="https://the1807.xyz/assets/images/ai.webp" />
+  <meta property="og:site_name" content="The 1807" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="ELKA-0 | The1807" />
+  <meta name="twitter:description" content="Open cognitive engine for memory-native embodied AI systems." />
+  <meta name="twitter:image" content="https://the1807.xyz/assets/images/ai.webp" />
+
+  <link rel="icon" href="/favicon.ico" sizes="any" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/components.css" />
+  <link rel="stylesheet" href="/assets/css/pages.css" />
+  <link rel="stylesheet" href="/assets/css/elka-0.css" />
+
+  <script>
+    // Update this if the repository slug changes.
+    window.ELKA_LINKS = {
+      ELKA_REPO_URL: 'https://github.com/vebbaybi/ELKA-0',
+      ELKA_FORK_URL: 'https://github.com/vebbaybi/ELKA-0/fork',
+      ELKA_DOWNLOAD_URL: 'https://github.com/vebbaybi/ELKA-0/archive/refs/heads/main.zip',
+      ELKA_DOCS_URL: 'https://github.com/vebbaybi/ELKA-0#readme',
+      ELKA_ARCH_URL: 'https://github.com/vebbaybi/ELKA-0#architecture',
+      ELKA_CONTRIBUTE_URL: 'https://github.com/vebbaybi/ELKA-0/blob/main/CONTRIBUTING.md',
+      ELKA_ISSUES_URL: 'https://github.com/vebbaybi/ELKA-0/issues'
+    };
+  </script>
+</head>
+
+<body class="theme-dark" data-route="elka-0">
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header-placeholder></header-placeholder>
+  <nav-placeholder></nav-placeholder>
+
+  <main id="main" class="elka-main" tabindex="-1">
+    <section class="elka-section elka-hero" aria-labelledby="elka-title">
+      <div class="elka-surface">
+        <p class="elka-eyebrow">The1807 · Cognitive Infrastructure</p>
+        <h1 id="elka-title" class="elka-title">ELKA-0</h1>
+        <p class="elka-subtitle">Open cognitive engine for memory-native embodied AI.</p>
+        <p class="elka-lead">ELKA-0 is the cognition layer designed to power Kael and future real-world AI systems through persistent memory, multimodal grounding, structured planning, and safety-aware decisions.</p>
+        <div class="elka-cta" role="group" aria-label="Primary ELKA-0 actions">
+          <a class="btn btn--elka" data-elka-link="ELKA_REPO_URL" target="_blank" rel="noopener noreferrer">View Repository</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_FORK_URL" target="_blank" rel="noopener noreferrer">Fork / Download</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_ARCH_URL" target="_blank" rel="noopener noreferrer">Read Architecture</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="identity-stack-title">
+      <div class="elka-surface">
+        <h2 id="identity-stack-title">Identity Stack</h2>
+        <p class="elka-intro">The1807 → Kael → ELKA-0 defines the product stack clearly for contributors and integrators.</p>
+        <div class="stack-flow" role="list" aria-label="The1807 product stack">
+          <article class="stack-node" role="listitem"><strong>The1807</strong><br />Parent builder ecosystem for applied AI systems.</article>
+          <div class="stack-arrow" aria-hidden="true">→</div>
+          <article class="stack-node" role="listitem"><strong>Kael</strong><br />User-facing AI runtime responsible for orchestration and execution.</article>
+          <div class="stack-arrow" aria-hidden="true">→</div>
+          <article class="stack-node" role="listitem"><strong>ELKA-0</strong><br />Cognitive engine that reasons, remembers, plans, and scores safety.</article>
+        </div>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="what-is-title">
+      <div class="elka-surface">
+        <h2 id="what-is-title">What ELKA-0 Is</h2>
+        <ul class="elka-list" role="list">
+          <li>Cognitive engine for real-world AI systems.</li>
+          <li>Memory-native reasoning layer.</li>
+          <li>Multimodal interpretation layer for text, sensor, and event streams.</li>
+          <li>Structured planning layer for deterministic action plans.</li>
+          <li>Safety-aware decision layer that constrains risky outputs.</li>
+          <li>Reusable AI core designed for Kael, AinorLiving, Campball, and future The1807 projects.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="what-not-title">
+      <div class="elka-surface">
+        <h2 id="what-not-title">What ELKA-0 Is Not</h2>
+        <ul class="elka-list" role="list">
+          <li>Not the full Kael system.</li>
+          <li>Not a GUI application.</li>
+          <li>Not hardware firmware.</li>
+          <li>Not MQTT infrastructure.</li>
+          <li>Not authentication / ACL infrastructure.</li>
+          <li>Not a vector database engine.</li>
+          <li>Not a thin chatbot wrapper.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="capabilities-title">
+      <div class="elka-surface">
+        <h2 id="capabilities-title">Core Capabilities</h2>
+        <ul class="elka-grid" role="list">
+          <li>Retrieval-native memory</li>
+          <li>Multimodal grounding</li>
+          <li>Structured action planning</li>
+          <li>Temporal reasoning</li>
+          <li>World modeling</li>
+          <li>Uncertainty awareness</li>
+          <li>Stable persona</li>
+          <li>Safety conditioning</li>
+          <li>Long-horizon reasoning</li>
+          <li>Interruptible dialogue</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="use-title">
+      <div class="elka-surface">
+        <h2 id="use-title">Real-World AI Use</h2>
+        <ul class="use-grid" role="list">
+          <li><strong>Kael:</strong> Uses ELKA-0 as the cognition core while Kael runtime layers handle execution.</li>
+          <li><strong>AinorLiving:</strong> Supplies room and home context signals for grounded cognition.</li>
+          <li><strong>Campball Sentinel:</strong> Sends environment and event telemetry into Kael/ELKA reasoning paths.</li>
+          <li><strong>Future The1807 Systems:</strong> Reuse ELKA-0 contracts for memory, planning, and safety logic.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="flow-title">
+      <div class="elka-surface">
+        <h2 id="flow-title">Architecture Flow</h2>
+        <ol class="elka-flow" aria-label="ELKA-0 architecture flow">
+          <li class="flow-step">User / Sensor / Device Event</li>
+          <li class="flow-arrow" aria-hidden="true">→</li>
+          <li class="flow-step">Kael Runtime</li>
+          <li class="flow-arrow" aria-hidden="true">→</li>
+          <li class="flow-step">ELKA-0 Cognition</li>
+          <li class="flow-arrow" aria-hidden="true">→</li>
+          <li class="flow-step">Memory + Perception + Planning + Safety</li>
+          <li class="flow-arrow" aria-hidden="true">→</li>
+          <li class="flow-step">Structured Response / Action Plan</li>
+          <li class="flow-arrow" aria-hidden="true">→</li>
+          <li class="flow-step">Kael Execution Layer</li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="developer-title">
+      <div class="elka-surface">
+        <h2 id="developer-title">Developer Integration</h2>
+        <ul class="dev-grid" role="list">
+          <li>Standalone engine first, then importable into Kael runtime.</li>
+          <li>Typed interfaces for cognition modules.</li>
+          <li>Structured input/output contracts for deterministic tooling.</li>
+          <li>External memory backends supported by interface adapters.</li>
+          <li>Model provider agnostic inference pathways.</li>
+          <li>Local, hybrid, edge, and high-compute deployment paths.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="oss-title">
+      <div class="elka-surface">
+        <h2 id="oss-title">Open Source</h2>
+        <ul class="oss-grid" role="list">
+          <li><strong>License:</strong> See repository license file for active license selection.</li>
+          <li><strong>Status:</strong> Early architecture and implementation phase; interfaces are stabilizing.<div class="status-chip">Transparent project maturity</div></li>
+          <li><strong>Repository:</strong> Source, issues, and pull requests are managed publicly.</li>
+        </ul>
+        <div class="elka-cta" role="group" aria-label="Open source actions">
+          <a class="btn btn--elka" data-elka-link="ELKA_REPO_URL" target="_blank" rel="noopener noreferrer">Repository</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_FORK_URL" target="_blank" rel="noopener noreferrer">Fork on GitHub</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_DOWNLOAD_URL" target="_blank" rel="noopener noreferrer">Download</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_CONTRIBUTE_URL" target="_blank" rel="noopener noreferrer">Contribute</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_DOCS_URL" target="_blank" rel="noopener noreferrer">Read Docs</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="deploy-title">
+      <div class="elka-surface">
+        <h2 id="deploy-title">Deployment Modes</h2>
+        <ul class="deployment-grid" role="list">
+          <li><strong>Local Mode:</strong> On-device cognition for private environments and offline resilience.</li>
+          <li><strong>Hybrid Mode:</strong> Local control with optional cloud inference or long-context support.</li>
+          <li><strong>Edge Fallback:</strong> Reduced cognition path for intermittent network or constrained devices.</li>
+          <li><strong>High-Compute Mode:</strong> Multi-model, higher-depth cognition for complex planning workloads.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="evaluation-title">
+      <div class="elka-surface">
+        <h2 id="evaluation-title">Evaluation Targets</h2>
+        <ul class="eval-grid" role="list">
+          <li>Memory recall accuracy</li>
+          <li>Hallucination reduction</li>
+          <li>Action safety</li>
+          <li>Interruption handling</li>
+          <li>Response latency</li>
+          <li>Anomaly reasoning</li>
+          <li>Persona consistency</li>
+          <li>Multimodal grounding fidelity</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="roadmap-title">
+      <div class="elka-surface">
+        <h2 id="roadmap-title">Roadmap</h2>
+        <ol class="roadmap">
+          <li><code>v0</code> Cognitive engine contract and core implementation.</li>
+          <li><code>v0.1</code> Memory-native reasoning.</li>
+          <li><code>v0.2</code> Multimodal event grounding.</li>
+          <li><code>v0.3</code> Structured planning and safety policy.</li>
+          <li><code>v0.4</code> Kael integration.</li>
+          <li><code>v1.0</code> Stable public release.</li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="final-cta-title">
+      <div class="elka-surface final-cta">
+        <h2 id="final-cta-title">Fork ELKA-0. Build cognition that remembers, reasons, and acts safely.</h2>
+        <div class="elka-cta elka-cta--center">
+          <a class="btn btn--elka" data-elka-link="ELKA_FORK_URL" target="_blank" rel="noopener noreferrer">Fork ELKA-0</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_ISSUES_URL" target="_blank" rel="noopener noreferrer">Join Discussions</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer-placeholder></footer-placeholder>
+
+  <script>
+    const links = window.ELKA_LINKS || {};
+    document.querySelectorAll('[data-elka-link]').forEach((anchor) => {
+      const key = anchor.getAttribute('data-elka-link');
+      if (links[key]) {
+        anchor.href = links[key];
+      }
+    });
+  </script>
+  <script type="module" src="/assets/js/app.js"></script>
+  <script type="module" src="/assets/js/ui/theme.js"></script>
+  <script type="module" src="/assets/js/ui/components/nav.js"></script>
+</body>
+
+</html>

--- a/elka-0/index.html
+++ b/elka-0/index.html
@@ -1,0 +1,259 @@
+<!DOCTYPE html>
+<html lang="en" data-app="1807" data-page="elka-0" data-version="v1.0">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <title>ELKA-0 | The1807</title>
+  <link rel="canonical" href="https://the1807.xyz/elka-0/" />
+  <meta name="description" content="Open cognitive engine for memory-native embodied AI systems." />
+  <meta name="keywords" content="ELKA-0, The1807, Kael, cognitive engine, open-source AI, embodied AI, memory-native AI, multimodal AI" />
+  <meta name="theme-color" content="#07090f" />
+  <meta name="robots" content="index,follow,max-image-preview:large" />
+
+  <meta property="og:title" content="ELKA-0 | The1807" />
+  <meta property="og:description" content="Open cognitive engine for memory-native embodied AI systems." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://the1807.xyz/elka-0/" />
+  <meta property="og:image" content="https://the1807.xyz/assets/images/ai.webp" />
+  <meta property="og:site_name" content="The 1807" />
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="ELKA-0 | The1807" />
+  <meta name="twitter:description" content="Open cognitive engine for memory-native embodied AI systems." />
+  <meta name="twitter:image" content="https://the1807.xyz/assets/images/ai.webp" />
+
+  <link rel="icon" href="/favicon.ico" sizes="any" />
+  <link rel="stylesheet" href="/assets/css/main.css" />
+  <link rel="stylesheet" href="/assets/css/components.css" />
+  <link rel="stylesheet" href="/assets/css/pages.css" />
+  <link rel="stylesheet" href="/assets/css/elka-0.css" />
+
+  <script>
+    // Update this if the repository slug changes.
+    window.ELKA_LINKS = {
+      ELKA_REPO_URL: 'https://github.com/vebbaybi/ELKA-0',
+      ELKA_FORK_URL: 'https://github.com/vebbaybi/ELKA-0/fork',
+      ELKA_DOWNLOAD_URL: 'https://github.com/vebbaybi/ELKA-0/archive/refs/heads/main.zip',
+      ELKA_DOCS_URL: 'https://github.com/vebbaybi/ELKA-0#readme',
+      ELKA_ARCH_URL: 'https://github.com/vebbaybi/ELKA-0#architecture',
+      ELKA_CONTRIBUTE_URL: 'https://github.com/vebbaybi/ELKA-0/blob/main/CONTRIBUTING.md',
+      ELKA_ISSUES_URL: 'https://github.com/vebbaybi/ELKA-0/issues'
+    };
+  </script>
+</head>
+
+<body class="theme-dark" data-route="elka-0">
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header-placeholder></header-placeholder>
+  <nav-placeholder></nav-placeholder>
+
+  <main id="main" class="elka-main" tabindex="-1">
+    <section class="elka-section elka-hero" aria-labelledby="elka-title">
+      <div class="elka-surface">
+        <p class="elka-eyebrow">The1807 · Cognitive Infrastructure</p>
+        <h1 id="elka-title" class="elka-title">ELKA-0</h1>
+        <p class="elka-subtitle">Open cognitive engine for memory-native embodied AI.</p>
+        <p class="elka-lead">ELKA-0 is the cognition layer designed to power Kael and future real-world AI systems through persistent memory, multimodal grounding, structured planning, and safety-aware decisions.</p>
+        <div class="elka-cta" role="group" aria-label="Primary ELKA-0 actions">
+          <a class="btn btn--elka" data-elka-link="ELKA_REPO_URL" target="_blank" rel="noopener noreferrer">View Repository</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_FORK_URL" target="_blank" rel="noopener noreferrer">Fork / Download</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_ARCH_URL" target="_blank" rel="noopener noreferrer">Read Architecture</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="identity-stack-title">
+      <div class="elka-surface">
+        <h2 id="identity-stack-title">Identity Stack</h2>
+        <p class="elka-intro">The1807 → Kael → ELKA-0 defines the product stack clearly for contributors and integrators.</p>
+        <div class="stack-flow" role="list" aria-label="The1807 product stack">
+          <article class="stack-node" role="listitem"><strong>The1807</strong><br />Parent builder ecosystem for applied AI systems.</article>
+          <div class="stack-arrow" aria-hidden="true">→</div>
+          <article class="stack-node" role="listitem"><strong>Kael</strong><br />User-facing AI runtime responsible for orchestration and execution.</article>
+          <div class="stack-arrow" aria-hidden="true">→</div>
+          <article class="stack-node" role="listitem"><strong>ELKA-0</strong><br />Cognitive engine that reasons, remembers, plans, and scores safety.</article>
+        </div>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="what-is-title">
+      <div class="elka-surface">
+        <h2 id="what-is-title">What ELKA-0 Is</h2>
+        <ul class="elka-list" role="list">
+          <li>Cognitive engine for real-world AI systems.</li>
+          <li>Memory-native reasoning layer.</li>
+          <li>Multimodal interpretation layer for text, sensor, and event streams.</li>
+          <li>Structured planning layer for deterministic action plans.</li>
+          <li>Safety-aware decision layer that constrains risky outputs.</li>
+          <li>Reusable AI core designed for Kael, AinorLiving, Campball, and future The1807 projects.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="what-not-title">
+      <div class="elka-surface">
+        <h2 id="what-not-title">What ELKA-0 Is Not</h2>
+        <ul class="elka-list" role="list">
+          <li>Not the full Kael system.</li>
+          <li>Not a GUI application.</li>
+          <li>Not hardware firmware.</li>
+          <li>Not MQTT infrastructure.</li>
+          <li>Not authentication / ACL infrastructure.</li>
+          <li>Not a vector database engine.</li>
+          <li>Not a thin chatbot wrapper.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="capabilities-title">
+      <div class="elka-surface">
+        <h2 id="capabilities-title">Core Capabilities</h2>
+        <ul class="elka-grid" role="list">
+          <li>Retrieval-native memory</li>
+          <li>Multimodal grounding</li>
+          <li>Structured action planning</li>
+          <li>Temporal reasoning</li>
+          <li>World modeling</li>
+          <li>Uncertainty awareness</li>
+          <li>Stable persona</li>
+          <li>Safety conditioning</li>
+          <li>Long-horizon reasoning</li>
+          <li>Interruptible dialogue</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="use-title">
+      <div class="elka-surface">
+        <h2 id="use-title">Real-World AI Use</h2>
+        <ul class="use-grid" role="list">
+          <li><strong>Kael:</strong> Uses ELKA-0 as the cognition core while Kael runtime layers handle execution.</li>
+          <li><strong>AinorLiving:</strong> Supplies room and home context signals for grounded cognition.</li>
+          <li><strong>Campball Sentinel:</strong> Sends environment and event telemetry into Kael/ELKA reasoning paths.</li>
+          <li><strong>Future The1807 Systems:</strong> Reuse ELKA-0 contracts for memory, planning, and safety logic.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="flow-title">
+      <div class="elka-surface">
+        <h2 id="flow-title">Architecture Flow</h2>
+        <ol class="elka-flow" aria-label="ELKA-0 architecture flow">
+          <li class="flow-step">User / Sensor / Device Event</li>
+          <li class="flow-arrow" aria-hidden="true">→</li>
+          <li class="flow-step">Kael Runtime</li>
+          <li class="flow-arrow" aria-hidden="true">→</li>
+          <li class="flow-step">ELKA-0 Cognition</li>
+          <li class="flow-arrow" aria-hidden="true">→</li>
+          <li class="flow-step">Memory + Perception + Planning + Safety</li>
+          <li class="flow-arrow" aria-hidden="true">→</li>
+          <li class="flow-step">Structured Response / Action Plan</li>
+          <li class="flow-arrow" aria-hidden="true">→</li>
+          <li class="flow-step">Kael Execution Layer</li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="developer-title">
+      <div class="elka-surface">
+        <h2 id="developer-title">Developer Integration</h2>
+        <ul class="dev-grid" role="list">
+          <li>Standalone engine first, then importable into Kael runtime.</li>
+          <li>Typed interfaces for cognition modules.</li>
+          <li>Structured input/output contracts for deterministic tooling.</li>
+          <li>External memory backends supported by interface adapters.</li>
+          <li>Model provider agnostic inference pathways.</li>
+          <li>Local, hybrid, edge, and high-compute deployment paths.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="oss-title">
+      <div class="elka-surface">
+        <h2 id="oss-title">Open Source</h2>
+        <ul class="oss-grid" role="list">
+          <li><strong>License:</strong> See repository license file for active license selection.</li>
+          <li><strong>Status:</strong> Early architecture and implementation phase; interfaces are stabilizing.<div class="status-chip">Transparent project maturity</div></li>
+          <li><strong>Repository:</strong> Source, issues, and pull requests are managed publicly.</li>
+        </ul>
+        <div class="elka-cta" role="group" aria-label="Open source actions">
+          <a class="btn btn--elka" data-elka-link="ELKA_REPO_URL" target="_blank" rel="noopener noreferrer">Repository</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_FORK_URL" target="_blank" rel="noopener noreferrer">Fork on GitHub</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_DOWNLOAD_URL" target="_blank" rel="noopener noreferrer">Download</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_CONTRIBUTE_URL" target="_blank" rel="noopener noreferrer">Contribute</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_DOCS_URL" target="_blank" rel="noopener noreferrer">Read Docs</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="deploy-title">
+      <div class="elka-surface">
+        <h2 id="deploy-title">Deployment Modes</h2>
+        <ul class="deployment-grid" role="list">
+          <li><strong>Local Mode:</strong> On-device cognition for private environments and offline resilience.</li>
+          <li><strong>Hybrid Mode:</strong> Local control with optional cloud inference or long-context support.</li>
+          <li><strong>Edge Fallback:</strong> Reduced cognition path for intermittent network or constrained devices.</li>
+          <li><strong>High-Compute Mode:</strong> Multi-model, higher-depth cognition for complex planning workloads.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="evaluation-title">
+      <div class="elka-surface">
+        <h2 id="evaluation-title">Evaluation Targets</h2>
+        <ul class="eval-grid" role="list">
+          <li>Memory recall accuracy</li>
+          <li>Hallucination reduction</li>
+          <li>Action safety</li>
+          <li>Interruption handling</li>
+          <li>Response latency</li>
+          <li>Anomaly reasoning</li>
+          <li>Persona consistency</li>
+          <li>Multimodal grounding fidelity</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="roadmap-title">
+      <div class="elka-surface">
+        <h2 id="roadmap-title">Roadmap</h2>
+        <ol class="roadmap">
+          <li><code>v0</code> Cognitive engine contract and core implementation.</li>
+          <li><code>v0.1</code> Memory-native reasoning.</li>
+          <li><code>v0.2</code> Multimodal event grounding.</li>
+          <li><code>v0.3</code> Structured planning and safety policy.</li>
+          <li><code>v0.4</code> Kael integration.</li>
+          <li><code>v1.0</code> Stable public release.</li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="elka-section" aria-labelledby="final-cta-title">
+      <div class="elka-surface final-cta">
+        <h2 id="final-cta-title">Fork ELKA-0. Build cognition that remembers, reasons, and acts safely.</h2>
+        <div class="elka-cta elka-cta--center">
+          <a class="btn btn--elka" data-elka-link="ELKA_FORK_URL" target="_blank" rel="noopener noreferrer">Fork ELKA-0</a>
+          <a class="btn secondary btn--elka" data-elka-link="ELKA_ISSUES_URL" target="_blank" rel="noopener noreferrer">Join Discussions</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer-placeholder></footer-placeholder>
+
+  <script>
+    const links = window.ELKA_LINKS || {};
+    document.querySelectorAll('[data-elka-link]').forEach((anchor) => {
+      const key = anchor.getAttribute('data-elka-link');
+      if (links[key]) {
+        anchor.href = links[key];
+      }
+    });
+  </script>
+  <script type="module" src="/assets/js/app.js"></script>
+  <script type="module" src="/assets/js/ui/theme.js"></script>
+  <script type="module" src="/assets/js/ui/components/nav.js"></script>
+</body>
+
+</html>

--- a/projects.html
+++ b/projects.html
@@ -94,7 +94,8 @@
                                         <h2 class="project-title"><a href="/ai/">AI & Cognitive Systems</a></h2>
                                         <p class="project-blurb">
                                             <strong>Luna:</strong> On-device neural assistant (PyQt5).<br />
-                                            <strong>Ainor:</strong> Living AI with vision, memory, and Svelte GUI.
+                                            <strong>Ainor:</strong> Living AI with vision, memory, and Svelte GUI.<br />
+                                            <strong>ELKA-0:</strong> Open cognitive engine for memory-native embodied AI.
                                         </p>
                                         <div class="project-meta" aria-hidden="true">
                                             <span>• Python</span> <span class="footer-right dot">•</span>
@@ -102,6 +103,7 @@
                                             <span>Svelte</span>
                                         </div>
                                         <a class="btn" href="/ai/">View AI</a>
+                                        <a class="btn secondary" href="/elka-0/">ELKA-0</a>
                                     </div>
                                 </article>
                             </li>

--- a/projects/index.html
+++ b/projects/index.html
@@ -94,7 +94,8 @@
                                         <h2 class="project-title"><a href="/ai/">AI & Cognitive Systems</a></h2>
                                         <p class="project-blurb">
                                             <strong>Luna:</strong> On-device neural assistant (PyQt5).<br />
-                                            <strong>Ainor:</strong> Living AI with vision, memory, and Svelte GUI.
+                                            <strong>Ainor:</strong> Living AI with vision, memory, and Svelte GUI.<br />
+                                            <strong>ELKA-0:</strong> Open cognitive engine for memory-native embodied AI.
                                         </p>
                                         <div class="project-meta" aria-hidden="true">
                                             <span>• Python</span> <span class="footer-right dot">•</span>
@@ -102,6 +103,7 @@
                                             <span>Svelte</span>
                                         </div>
                                         <a class="btn" href="/ai/">View AI</a>
+                                        <a class="btn secondary" href="/elka-0/">ELKA-0</a>
                                     </div>
                                 </article>
                             </li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -138,4 +138,10 @@
     <changefreq>monthly</changefreq>
     <priority>0.72</priority>
   </url>
+  <url>
+    <loc>https://the1807.xyz/elka-0/</loc>
+    <lastmod>2026-04-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.84</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
### Motivation
- Provide a production-ready, developer-first ELKA-0 landing page that explains purpose, boundaries, architecture, roadmap, and clear repo/download/docs actions for The1807 portfolio.
- Surface ELKA-0 in AI/Projects site areas so contributors and integrators can discover the engine from existing navigation surfaces.
- Fix follow-up HTML/accessibility and style issues to keep semantics and presentation separate.

### Description
- Added new route pages `elka-0.html` and `elka-0/index.html` with Hero, Identity Stack, What ELKA-0 Is / Is Not, Core Capabilities, Real-World Use, Architecture Flow, Developer Integration, Open Source, Deployment Modes, Evaluation Targets, Roadmap, and Final CTA sections, plus SEO/Open Graph/Twitter metadata.
- Added `assets/css/elka-0.css` implementing a dark premium visual language, responsive grids, architecture motifs, and utility class `.elka-cta--center` used for CTA alignment.
- Integrated ELKA-0 into portfolio surfaces by updating `ai.html`/`ai/index.html` and `projects.html`/`projects/index.html` to include discoverability links/cards, and added the page URL to `sitemap.xml`.
- Centralized external targets with `window.ELKA_LINKS` and `data-elka-link` attributes for all repo/fork/download/docs CTAs, removed a duplicate `roadmap` heading id, and replaced inline CTA styles with the `.elka-cta--center` CSS utility.

### Testing
- Ran `git diff --check` to validate whitespace/format issues and received no blocking errors (passed).
- Searched references with `rg -n "ELKA-0|elka-0|roadmap-title|elka-cta--center"` across changed files to confirm new pages, IDs, and CSS utility are present (found and validated).
- Verified modified files are staged/committed locally with `git status --short` and recent history checks (no outstanding local errors).
- Note: visual browser screenshot capture was not available in this environment, so please serve locally (for example `python -m http.server 8000`) and open `http://localhost:8000/elka-0/` to visually validate layout and responsiveness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7e135d8483308e45470be979813f)